### PR TITLE
Changed install.sh hashbang from sh to bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # CellPhy installation script 
 # Created by: Alexey Kozlov, Joao M Alves, Alexandros Stamatakis & David Posada - July 2025
 


### PR DESCRIPTION
Hi, 

I get the following error when running `install.sh` from Ubuntu 22.04
```
Operating system detected: ubuntu
./install.sh: 21: [: ubuntu: unexpected operator
./install.sh: 23: [: ubuntu: unexpected operator
./install.sh: 25: [: ubuntu: unexpected operator
Unknown OS: ubuntu
./install.sh: 21: [: ubuntu: unexpected operator
./install.sh: 23: [: ubuntu: unexpected operator
./install.sh: 25: [: ubuntu: unexpected operator
Unknown OS: ubuntu
Installing required R packages...
/usr/bin/env: ‘Rscript’: No such file or directory
Done!
```

Replacing `#!/bin/sh` with `#!/bin/bash` fixes the issue on my ubuntu. 